### PR TITLE
PlaceResponseDTO 수정

### DIFF
--- a/src/main/java/com/kumoh/cosmoa/dto/PlaceResponseDTO.java
+++ b/src/main/java/com/kumoh/cosmoa/dto/PlaceResponseDTO.java
@@ -46,6 +46,7 @@ public class PlaceResponseDTO {
         this.modifiedDate = dto.getModifiedDate();
 
         try {
+            if (dto.getImgPath() == null) return;
             Path path = Paths.get(dto.getImgPath());
             byte[] bytes = Files.readAllBytes(path);
 //            File file = new File(dto.getImgPath());


### PR DESCRIPTION
이미지 경로가 null일 때, 예외처리하지 않아서 500 error 발생하여 수정